### PR TITLE
Replace global-req middleware, rename injectable data-fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ Now you can call `get_most_recent_order` as many times as you want within a requ
 
 ### Batching
 
-This library also supports _batching_ fetching logic. You need to subclass our `InjectibleDataFetcher` class and implement a `batch_load` (or `batch_load_dict`) method with the batching logic. Then you can use its factory method to get an instance of your fetcher class, and call its `get()`, `get_many()`, or `prefetch_keys()` methods. 
+This library also supports _batching_ fetching logic. You need to subclass our `DataFetcher` class and implement a `batch_load` (or `batch_load_dict`) method with the batching logic. Then you can use its factory method to get an instance of your fetcher class, and call its `get()`, `get_many()`, or `prefetch_keys()` methods. 
 
 For example, it's usually pretty difficult to efficiently fetch permissions for a list of objects without coupling your view to your templates/helpers. With this library, we can offload the work to a data-fetcher instance and have a re-usable template-helper that checks permissions. When we notice performance problems, we simply add a `prefetch_keys` call to our view to pre-populate the cache. 
 
 ```python
 # my_app/fetchers.py
 
-from data_fetcher import InjectibleDataFetcher
+from data_fetcher import DataFetcher
 
-class ArticlePermissionFetcher(InjectibleDataFetcher):
+class ArticlePermissionFetcher(DataFetcher):
     def batch_load_dict(self, article_ids):
         permissions = ArticlePermission.objects.filter(article_id__in=article_ids)
         return {p.article_id: p for p in permissions}

--- a/data_fetcher/__init__.py
+++ b/data_fetcher/__init__.py
@@ -1,6 +1,6 @@
 from data_fetcher.middleware import GlobalRequest
 
-from .core import InjectableDataFetcher
+from .core import DataFetcher
 from .extras import ValueBoundDataFetcher, cache_within_request
 from .shorthand_fetcher_classes import (
     AbstractChildModelByAttrFetcher,

--- a/data_fetcher/__init__.py
+++ b/data_fetcher/__init__.py
@@ -1,4 +1,4 @@
-from django_middleware_global_request import GlobalRequest
+from data_fetcher.middleware import GlobalRequest
 
 from .core import InjectableDataFetcher
 from .extras import ValueBoundDataFetcher, cache_within_request

--- a/data_fetcher/core.py
+++ b/data_fetcher/core.py
@@ -52,7 +52,7 @@ class BaseDataFetcher:
         self._cache[key] = value
 
 
-class InjectableDataFetcher(BaseDataFetcher):
+class DataFetcher(BaseDataFetcher):
     """
     Factory for creating composable datafetchers
     """
@@ -65,7 +65,7 @@ class InjectableDataFetcher(BaseDataFetcher):
     def __init__(self, create_key):
         # Hacky way to make constructor "private"
         assert (
-            create_key == InjectableDataFetcher.__create_key
+            create_key == DataFetcher.__create_key
         ), "Never create data-fetcher instances directly, use get_instance"
 
         super().__init__()
@@ -81,8 +81,6 @@ class InjectableDataFetcher(BaseDataFetcher):
                 fetcher_instance_cache = {}
 
         if cls not in fetcher_instance_cache:
-            fetcher_instance_cache[cls] = cls(
-                InjectableDataFetcher.__create_key
-            )
+            fetcher_instance_cache[cls] = cls(DataFetcher.__create_key)
 
         return fetcher_instance_cache[cls]

--- a/data_fetcher/extras.py
+++ b/data_fetcher/extras.py
@@ -1,6 +1,6 @@
 from functools import cache, wraps
 
-from .core import InjectableDataFetcher
+from .core import DataFetcher
 from .util import MissingRequestContextException, get_datafetcher_request_cache
 
 
@@ -73,7 +73,7 @@ class ValueBoundFetcherFactory:
             return fetcher
 
 
-class ValueBoundDataFetcher(InjectableDataFetcher):
+class ValueBoundDataFetcher(DataFetcher):
     """
     To be used as a parent class for keyed-datafetchers
 

--- a/data_fetcher/global_request_context.py
+++ b/data_fetcher/global_request_context.py
@@ -1,0 +1,28 @@
+import contextvars
+
+from django.http import HttpRequest
+
+storage = contextvars.ContextVar("request", default=None)
+
+
+class GlobalRequest:
+    """
+    get_request() will return the same object
+    within this ctx-manager's block
+
+    """
+
+    def __init__(self, request=None):
+        self.new_request = request or HttpRequest()
+        self.old_request = storage.get()
+
+    def __enter__(self):
+        storage.set(self.new_request)
+        return storage.get()
+
+    def __exit__(self, *args, **kwargs):
+        storage.set(self.old_request)
+
+
+def get_request():
+    return storage.get()

--- a/data_fetcher/middleware.py
+++ b/data_fetcher/middleware.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+from __future__ import (
+    absolute_import,
+    division,
+    generators,
+    nested_scopes,
+    print_function,
+    unicode_literals,
+    with_statement,
+)
+
+import threading
+
+from django.http import HttpRequest
+
+
+class GlobalRequestStorage(object):
+    storage = threading.local()
+
+    def get(self):
+        if hasattr(self.storage, "request"):
+            return self.storage.request
+        else:
+            return None
+
+    def get_user(self, request=None):
+        request = request or self.get()
+        return getattr(request, "user", None)
+
+    def set(self, request):
+        self.storage.request = request
+
+    def set_user(self, user, request=None):
+        if request:
+            self.storage.request = request
+        if not hasattr(self.storage, "request"):
+            self.storage.request = HttpRequest()
+        if user:
+            self.storage.request.user = user
+
+    def recover(self, request=None, user=None):
+        if hasattr(self.storage, "request"):
+            del self.storage.request
+        if request:
+            self.storage.request = request
+            if user:
+                self.storage.request.user = user
+
+
+class GlobalRequest(object):
+
+    def __init__(self, request=None, user=None):
+        self.global_request_storage = GlobalRequestStorage()
+        self.new_request = request or HttpRequest()
+        self.new_user = user
+        self.old_request = self.global_request_storage.get()
+        self.old_user = self.global_request_storage.get_user(self.old_request)
+
+    def __enter__(self):
+        self.global_request_storage.set_user(
+            user=self.new_user, request=self.new_request
+        )
+        return self.global_request_storage.get()
+
+    def __exit__(self, *args, **kwargs):
+        self.global_request_storage.recover(
+            request=self.old_request, user=self.old_user
+        )
+
+
+class GlobalRequestMiddleware(object):
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        with GlobalRequest(request=request):
+            return self.get_response(request)
+
+
+def get_request():
+    return GlobalRequestStorage().get()

--- a/data_fetcher/middleware.py
+++ b/data_fetcher/middleware.py
@@ -1,55 +1,7 @@
-#!/usr/bin/env python
-# -*- coding: utf8 -*-
-from __future__ import (
-    absolute_import,
-    division,
-    generators,
-    nested_scopes,
-    print_function,
-    unicode_literals,
-    with_statement,
-)
-
-import threading
-
-from django.http import HttpRequest
+from .global_request_context import GlobalRequest
 
 
-class GlobalRequestStorage(object):
-    storage = threading.local()
-
-    def get(self):
-        if hasattr(self.storage, "request"):
-            return self.storage.request
-        else:
-            return None
-
-    def set(self, request):
-        self.storage.request = request
-
-    def recover(self, request=None):
-        if hasattr(self.storage, "request"):
-            del self.storage.request
-        if request:
-            self.storage.request = request
-
-
-class GlobalRequest(object):
-
-    def __init__(self, request=None):
-        self.global_request_storage = GlobalRequestStorage()
-        self.new_request = request or HttpRequest()
-        self.old_request = self.global_request_storage.get()
-
-    def __enter__(self):
-        self.global_request_storage.set(self.new_request)
-        return self.global_request_storage.get()
-
-    def __exit__(self, *args, **kwargs):
-        self.global_request_storage.recover(request=self.old_request)
-
-
-class GlobalRequestMiddleware(object):
+class GlobalRequestMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -57,7 +9,3 @@ class GlobalRequestMiddleware(object):
     def __call__(self, request):
         with GlobalRequest(request=request):
             return self.get_response(request)
-
-
-def get_request():
-    return GlobalRequestStorage().get()

--- a/data_fetcher/middleware.py
+++ b/data_fetcher/middleware.py
@@ -24,49 +24,29 @@ class GlobalRequestStorage(object):
         else:
             return None
 
-    def get_user(self, request=None):
-        request = request or self.get()
-        return getattr(request, "user", None)
-
     def set(self, request):
         self.storage.request = request
 
-    def set_user(self, user, request=None):
-        if request:
-            self.storage.request = request
-        if not hasattr(self.storage, "request"):
-            self.storage.request = HttpRequest()
-        if user:
-            self.storage.request.user = user
-
-    def recover(self, request=None, user=None):
+    def recover(self, request=None):
         if hasattr(self.storage, "request"):
             del self.storage.request
         if request:
             self.storage.request = request
-            if user:
-                self.storage.request.user = user
 
 
 class GlobalRequest(object):
 
-    def __init__(self, request=None, user=None):
+    def __init__(self, request=None):
         self.global_request_storage = GlobalRequestStorage()
         self.new_request = request or HttpRequest()
-        self.new_user = user
         self.old_request = self.global_request_storage.get()
-        self.old_user = self.global_request_storage.get_user(self.old_request)
 
     def __enter__(self):
-        self.global_request_storage.set_user(
-            user=self.new_user, request=self.new_request
-        )
+        self.global_request_storage.set(self.new_request)
         return self.global_request_storage.get()
 
     def __exit__(self, *args, **kwargs):
-        self.global_request_storage.recover(
-            request=self.old_request, user=self.old_user
-        )
+        self.global_request_storage.recover(request=self.old_request)
 
 
 class GlobalRequestMiddleware(object):

--- a/data_fetcher/shorthand_fetcher_classes.py
+++ b/data_fetcher/shorthand_fetcher_classes.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
 
-from .core import InjectableDataFetcher
+from .core import DataFetcher
 
 
-class AbstractModelByIdFetcher(InjectableDataFetcher):
+class AbstractModelByIdFetcher(DataFetcher):
     model = None  # override this part
 
     @classmethod
@@ -46,7 +46,7 @@ class PrimaryKeyFetcherFactory:
             return fetcher
 
 
-class AbstractChildModelByAttrFetcher(InjectableDataFetcher):
+class AbstractChildModelByAttrFetcher(DataFetcher):
     """
     Loads many records by a single attr, use this to create child-by-parent-id loaders
     """

--- a/data_fetcher/util.py
+++ b/data_fetcher/util.py
@@ -1,4 +1,5 @@
-from django_middleware_global_request import get_request
+# from data_fetcher.middleware import get_request
+from .middleware import get_request
 
 
 class MissingRequestContextException(Exception):

--- a/data_fetcher/util.py
+++ b/data_fetcher/util.py
@@ -1,5 +1,5 @@
 # from data_fetcher.middleware import get_request
-from .middleware import get_request
+from .global_request_context import GlobalRequest, get_request
 
 
 class MissingRequestContextException(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,6 @@ django-extensions==3.1.1
 Faker==4.0.0
 ipython==8.10.0
 
-# actual deps
-django-middleware-global-request==0.3.1
-
 # dev
 coverage==5.1
 django-debug-toolbar==3.7

--- a/sample_app/data_factories.py
+++ b/sample_app/data_factories.py
@@ -1,6 +1,16 @@
+from django.contrib.auth.models import User
+
 import factory
 
 from .models import Author, Book, Tag
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = User
+
+    username = factory.Faker("user_name")
+    email = factory.Faker("email")
 
 
 class TagFactory(factory.django.DjangoModelFactory):

--- a/sample_app/settings.py
+++ b/sample_app/settings.py
@@ -48,6 +48,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "data_fetcher.middleware.GlobalRequestMiddleware",
 ]
 
 ROOT_URLCONF = "sample_app.urls"

--- a/sample_app/urls.py
+++ b/sample_app/urls.py
@@ -13,13 +13,16 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.contrib.auth.views import LoginView
 from django.urls import path
 
-from .views import edit_book
+from .views import async_view_with_loaders, edit_book, view_with_loaders
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="login"),
     path("book/<int:pk>/edit/", edit_book, name="edit-book"),
+    path("view1", view_with_loaders, name="view1"),
+    path("async_view1", async_view_with_loaders, name="async_view1"),
 ]

--- a/sample_app/views.py
+++ b/sample_app/views.py
@@ -1,6 +1,10 @@
 from django.http.response import HttpResponse
 
-from .models import Book
+from asgiref.sync import sync_to_async
+
+from data_fetcher import PrimaryKeyFetcherFactory
+
+from .models import Author, Book, Tag
 
 
 def edit_book(request, pk=None):
@@ -11,3 +15,37 @@ def edit_book(request, pk=None):
         book.save()
 
     return HttpResponse()
+
+
+def spyable_func(*args, **kwargs):
+    # for testing purposes
+    return None
+
+
+AuthorByIdFetcher = PrimaryKeyFetcherFactory.get_model_by_id_fetcher(Author)
+
+
+class WatchedAuthorByIdFetcher(AuthorByIdFetcher):
+    def batch_load_dict(self, keys):
+        spyable_func(keys)
+        return super().batch_load_dict(keys)
+
+
+def get_author(author_id):
+    return WatchedAuthorByIdFetcher.get_instance().get(author_id)
+
+
+def view_with_loaders(request):
+    author_ids = Author.objects.values_list("id", flat=True)
+    all_authors = WatchedAuthorByIdFetcher.get_instance().get_many(author_ids)
+
+    for author in all_authors:
+        refetched_author = get_author(author.id)
+        assert refetched_author is author
+
+    return HttpResponse("ok")
+
+
+async def async_view_with_loaders(request):
+    resp = await sync_to_async(view_with_loaders)(request)
+    return resp

--- a/tests/test_data_fetchers.py
+++ b/tests/test_data_fetchers.py
@@ -3,14 +3,13 @@ from unittest.mock import MagicMock
 
 from django.contrib.auth import get_user_model
 
-from django_middleware_global_request import GlobalRequest, get_request
-
 from data_fetcher import (
     InjectableDataFetcher,
     PrimaryKeyFetcherFactory,
     cache_within_request,
     get_datafetcher_request_cache,
 )
+from data_fetcher.middleware import GlobalRequest, get_request
 
 
 def test_global_request_outside_request():

--- a/tests/test_data_fetchers.py
+++ b/tests/test_data_fetchers.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from django.contrib.auth import get_user_model
 
 from data_fetcher import (
-    InjectableDataFetcher,
+    DataFetcher,
     PrimaryKeyFetcherFactory,
     cache_within_request,
     get_datafetcher_request_cache,
@@ -79,7 +79,7 @@ def test_composed_datafetcher(django_assert_max_num_queries):
     spy = MagicMock()
 
     # Trivial example of dataloader composition
-    class TrivialOtherFetcher(InjectableDataFetcher):
+    class TrivialOtherFetcher(DataFetcher):
         def batch_load_dict(self, keys):
             spy(keys)
             user_fetcher = UserByPKFetcher.get_instance()
@@ -164,7 +164,7 @@ def test_batch_load_dict_none_value():
 
     spy = MagicMock()
 
-    class TestFetcher(InjectableDataFetcher):
+    class TestFetcher(DataFetcher):
         def batch_load_dict(self, keys):
             spy()
             return {"a": 1, "b": None}

--- a/tests/test_data_fetchers.py
+++ b/tests/test_data_fetchers.py
@@ -9,7 +9,7 @@ from data_fetcher import (
     cache_within_request,
     get_datafetcher_request_cache,
 )
-from data_fetcher.middleware import GlobalRequest, get_request
+from data_fetcher.util import GlobalRequest, get_request
 
 
 def test_global_request_outside_request():
@@ -21,6 +21,17 @@ def test_global_request_context_processor():
         assert get_request() is not None
         get_request().x = 1
         assert get_request().x == 1
+
+
+def test_global_request_returns_same_request():
+    with GlobalRequest():
+        r1 = get_request()
+        r2 = get_request()
+        assert r1 is r2
+    with GlobalRequest():
+        r3 = get_request()
+
+    assert r1 is not r3
 
 
 def test_user_datafetcher(django_assert_num_queries):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+from django.test.client import Client
+from django.urls import reverse
+
+from sample_app import data_factories
+
+
+def test_view_with_loader():
+    u = data_factories.UserFactory()
+    client1 = Client()
+    client1.force_login(u)
+
+    u2 = data_factories.UserFactory()
+    client2 = Client()
+    client2.force_login(u2)
+
+    data_factories.AuthorFactory.create_batch(20)
+
+    url = reverse("view1")
+
+    spy1 = MagicMock()
+
+    with patch("sample_app.views.spyable_func", spy1):
+        response = client1.get(url)
+        assert response.status_code == 200
+
+    spy2 = MagicMock()
+    with patch("sample_app.views.spyable_func", spy2):
+        response = client2.get(url)
+        assert response.status_code == 200
+
+    assert spy1.call_count == 1
+    assert spy2.call_count == 1
+
+
+def test_async_view_with_loader():
+    u = data_factories.UserFactory()
+    client1 = Client()
+    client1.force_login(u)
+
+    u2 = data_factories.UserFactory()
+    client2 = Client()
+    client2.force_login(u2)
+
+    data_factories.AuthorFactory.create_batch(20)
+
+    url = reverse("async_view1")
+
+    spy1 = MagicMock()
+
+    with patch("sample_app.views.spyable_func", spy1):
+        response = client1.get(url)
+        assert response.status_code == 200
+
+    spy2 = MagicMock()
+    with patch("sample_app.views.spyable_func", spy2):
+        response = client2.get(url)
+        assert response.status_code == 200
+
+    assert spy1.call_count == 1
+    assert spy2.call_count == 1


### PR DESCRIPTION
- remove dependency on global-request middleware with first-party async and thread safe context-var based middleware
- rename `InjectableDataFetcher` to just `DataFetcher`

Both are breaking changes